### PR TITLE
chore: upgrade Calcit to 0.13.15

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,5 +1,5 @@
 
-{} (:calcit-version |0.13.13)
+{} (:calcit-version |0.13.15)
   :dependencies $ {} (|Respo/reel.calcit |0.6.6)
     |Respo/respo-markdown.calcit |0.4.22
     |Respo/respo-ui.calcit |0.7.7

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "vite": "^8.2.1"
   },
   "dependencies": {
-    "@calcit/procs": "^0.13.13",
+    "@calcit/procs": "^0.13.15",
     "shortid": "^2.2.17"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.13":
-  version: 0.13.13
-  resolution: "@calcit/procs@npm:0.13.13"
+"@calcit/procs@npm:^0.13.15":
+  version: 0.13.15
+  resolution: "@calcit/procs@npm:0.13.15"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/2f05ccfef08bc971aea97536bf8dd3cb4f1edc67acad8d377b98ecd015a0b01ef674193d92b218c1623b56f772f09e19733b5ec45ab01f4dfba35a4ceadd6295
+  checksum: 10c0/f37687aac090b2a286f916ea3c9d9cc173d4f606d1f02d5e57e192cbf375277a05bcd5f0a75d890b2827635dec9959034046ea626fda8900b8fe2c7f5c4c3e8a
   languageName: node
   linkType: hard
 
@@ -566,7 +566,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "pudica-schedule@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.13"
+    "@calcit/procs": "npm:^0.13.15"
     bottom-tip: "npm:^0.1.5"
     shortid: "npm:^2.2.17"
     vite: "npm:^8.2.1"


### PR DESCRIPTION
Bump calcit-version 0.13.13 → 0.13.15, sync @calcit/procs. check-only passes.